### PR TITLE
Disable workspace discovery when initializing

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/mavenresolver/MavenRepositorySystemProducer.java
+++ b/runtime/src/main/java/io/quarkiverse/mavenresolver/MavenRepositorySystemProducer.java
@@ -16,7 +16,8 @@ public class MavenRepositorySystemProducer {
 
     public MavenRepositorySystemProducer() {
         try {
-            final BootstrapMavenContext mvnCtx = new BootstrapMavenContext();
+            final BootstrapMavenContext mvnCtx = new BootstrapMavenContext(
+                    BootstrapMavenContext.config().setWorkspaceDiscovery(false));
             repoSystem = mvnCtx.getRepositorySystem();
             remoteRepoManager = mvnCtx.getRemoteRepositoryManager();
         } catch (Exception e) {


### PR DESCRIPTION
Repository system initialization does not need the workspace.